### PR TITLE
PDF: Turn the PDF text into a tagged string

### DIFF
--- a/lib/Renard/Incunabula/Format/PDF/Document.pm
+++ b/lib/Renard/Incunabula/Format/PDF/Document.pm
@@ -143,7 +143,7 @@ method get_textual_page( (PageNumber) $page_number )
 		$page_number
 	);
 
-	my $levels = [ qw(doc page block line span char) ];
+	my $levels = [ qw(document page block line font char) ];
 	_walk_page_data( $page_st, $stext, 0, $levels );
 
 	$page_st;

--- a/lib/Renard/Incunabula/Format/PDF/Document.pm
+++ b/lib/Renard/Incunabula/Format/PDF/Document.pm
@@ -7,9 +7,12 @@ use Renard::Incunabula::MuPDF::mutool;
 use Renard::Incunabula::Format::PDF::Page;
 use Renard::Incunabula::Outline;
 use Renard::Incunabula::Document::Types qw(PageNumber ZoomLevel);
+use Renard::Incunabula::Common::Types qw(InstanceOf);
 
 use Math::Trig;
 use Math::Polygon;
+
+use String::Tagged;
 
 use Function::Parameters;
 
@@ -110,6 +113,64 @@ method _build_identity_bounds() {
 
 	return \@page_xy;
 }
+
+=method get_textual_page
+
+  method get_textual_page( (PageNumber) $page_number ) :ReturnType(InstanceOf['String::Tagged'])
+
+Returns a L<String::Tagged> representation of the PDF textual data for a given
+page. The return value contains tags that indicate the extent of each level as
+defined by L<Renard::Incunabula::MuPDF::mutool::get_mutool_text_stext_xml>:
+
+=for :list
+* C<page>,
+* C<block>,
+* C<line>,
+* C<span>, and
+* C<char>
+
+
+The values associated with these tags can be used to find the bounding box for
+the symbols on the page.
+
+=cut
+method get_textual_page( (PageNumber) $page_number )
+		:ReturnType(InstanceOf['String::Tagged']) {
+	my $page_st = String::Tagged->new;
+
+	my $stext = Renard::Incunabula::MuPDF::mutool::get_mutool_text_stext_xml(
+		$self->filename,
+		$page_number
+	);
+
+	my $levels = [ qw(doc page block line span char) ];
+	_walk_page_data( $page_st, $stext, 0, $levels );
+
+	$page_st;
+}
+
+fun _walk_page_data( $tagged, $data, $depth, $levels ) {
+	my $level_tagged = String::Tagged->new("");
+
+	if( $depth == @$levels - 1 ) {
+		# last level is the character, so we append that to the string
+		$level_tagged .= $data->{c};
+	} else {
+		# empty pages will not have this data
+		return unless exists $data->{ $levels->[$depth+1] };
+
+		my @data_next = @{ $data->{ $levels->[$depth+1] } };
+		for my $next_data (@data_next) {
+			_walk_page_data( $level_tagged, $next_data, $depth+1, $levels );
+		}
+	}
+	$level_tagged->apply_tag(0, $level_tagged->length, $levels->[$depth] => $data );
+
+	$tagged->append_tagged($level_tagged);
+
+	return;
+}
+
 
 with qw(
 	Renard::Incunabula::Document::Role::FromFile

--- a/t/Renard/Incunabula/Format/PDF/Document.t
+++ b/t/Renard/Incunabula/Format/PDF/Document.t
@@ -14,7 +14,7 @@ my $pdf_ref_path = try {
 	plan skip_all => "$_";
 };
 
-plan tests => 1;
+plan tests => 2;
 
 subtest pdf_ref => sub {
 	my $pdf_doc = Renard::Incunabula::Format::PDF::Document->new(
@@ -33,5 +33,30 @@ subtest pdf_ref => sub {
 	isa_ok $first_page->cairo_image_surface, 'Cairo::ImageSurface';
 };
 
+subtest "Textual information" => sub {
+	my $pdf_doc = Renard::Incunabula::Format::PDF::Document->new(
+		filename => $pdf_ref_path
+	);
+
+	my $tagged = $pdf_doc->get_textual_page( 23 );
+
+	my $tagged_line_bbox = "";
+	$tagged->iter_substr_nooverlap(
+		sub {
+			my ( $substring, %tags ) = @_;
+
+			$tagged_line_bbox .=
+				  $tags{line}
+				? "<line bbox='@{[ $tags{line}{bbox} ]}'>$substring</line>"
+				: $substring;
+		},
+		only => [ 'line' ],
+	);
+
+	like(
+		$tagged_line_bbox,
+		qr|\Q<line bbox='261.18 616.16397 269.77766 625.2532'>23</line>\E|,
+		"Stores the page number text and its metadata" );
+};
 
 done_testing;


### PR DESCRIPTION
This marks the extents of various PDF regions.