### PR TITLE
Retrieve document information dictionary

### DIFF
--- a/lib/Renard/Incunabula/Format/PDF/InformationDictionary.pm
+++ b/lib/Renard/Incunabula/Format/PDF/InformationDictionary.pm
@@ -1,0 +1,223 @@
+use Renard::Incunabula::Common::Setup;
+package Renard::Incunabula::Format::PDF::InformationDictionary;
+# ABSTRACT: represents the PDF document information dictionary
+
+use Moo;
+use Renard::Incunabula::Common::Types qw(Maybe File InstanceOf Str HashRef);
+use Renard::Incunabula::MuPDF::mutool;
+
+=attr filename
+
+A C<File> containing the path to a document.
+
+=cut
+has filename => (
+	is => 'ro',
+	isa => File,
+	coerce => 1,
+);
+
+has _object => (
+	is => 'lazy',
+	isa => InstanceOf['Renard::Incunabula::MuPDF::mutool::ObjectParser'],
+	handles => {
+	},
+);
+
+method _build__object() {
+	Renard::Incunabula::MuPDF::mutool::get_mutool_get_info_object_parsed( $self->filename );
+}
+
+method _get_data( (Str) $key ) {
+	my $obj = $self->_object->resolve_key($key);
+
+	return $obj->data if $obj;
+}
+
+=method Title
+
+=begin :list
+
+= Type
+
+text string
+
+= Description
+
+(Optional; PDF 1.1) The document’s title.
+
+=end :list
+
+=cut
+method Title() :ReturnType(Maybe[Str]) {
+	$self->_get_data('Title');
+}
+
+=method Subject
+
+=begin :list
+
+= Type
+
+text string
+
+= Description
+
+(Optional; PDF 1.1) The subject of the document.
+
+=end :list
+
+=cut
+method Subject() :ReturnType(Maybe[Str]) {
+	$self->_get_data('Subject');
+}
+
+=method Author
+
+=begin :list
+
+= Type
+
+text string
+
+= Description
+
+(Optional) The name of the person who created the document.
+
+=end :list
+
+=cut
+method Author() :ReturnType(Maybe[Str]) {
+	$self->_get_data('Author');
+}
+
+=method Keywords
+
+=begin :list
+
+= Type
+
+text string
+
+= Description
+
+(Optional; PDF 1.1) Keywords associated with the document.
+
+=end :list
+
+=cut
+method Keywords() :ReturnType(Maybe[Str]) {
+	$self->_get_data('Keywords');
+}
+
+=method Creator
+
+=begin :list
+
+= Type
+
+text string
+
+= Description
+
+(Optional) If the document was converted to PDF from another format, the
+name of the application (for example, Adobe FrameMaker®) that created the
+original document from which it was converted.
+
+=end :list
+
+=cut
+method Creator() :ReturnType(Maybe[Str]) {
+	$self->_get_data('Creator');
+}
+
+=method Producer
+
+=begin :list
+
+= Type
+
+text string
+
+= Description
+
+(Optional) If the document was converted to PDF from another format, the name
+of the application (for example, Acrobat Distiller) that converted it to PDF.
+
+=end :list
+
+=cut
+method Producer() :ReturnType(Maybe[Str]) {
+	$self->_get_data('Producer');
+}
+
+=method CreationDate
+
+=begin :list
+
+= Type
+
+date
+
+= Description
+
+(Optional) The date and time the document was created, in human-readable form
+(see Section 3.8.3, “Dates”).
+
+=end :list
+
+=cut
+method CreationDate() :ReturnType(Maybe[InstanceOf['Renard::Incunabula::MuPDF::mutool::DateObject']]) {
+	$self->_get_data('CreationDate');
+}
+
+=method ModDate
+
+=begin :list
+
+= Type
+
+date
+
+= Description
+
+(Required if PieceInfo is present in the document catalog; otherwise optional;
+PDF 1.1) The date and time the document was most recently modified, in
+human-readable form (see Section 3.8.3, “Dates”).
+
+=end :list
+
+=cut
+method ModDate() :ReturnType(Maybe[InstanceOf['Renard::Incunabula::MuPDF::mutool::DateObject']]) {
+	$self->_get_data('ModDate');
+}
+
+1;
+__END__
+=head1 DESCRIPTION
+
+Allows for access to the common fields used for the PDF document information
+dictionary.
+
+=head1 SEE ALSO
+
+Table 10.2 on pg. 844 of the I<PDF Reference, version 1.7> for more information.
+
+=cut
+
+=begin :header
+
+=begin stopwords
+
+CreationDate ModDate
+
+PieceInfo
+
+FrameMaker FrameMaker®
+
+=end stopwords
+
+=end :header
+
+
+=cut

--- a/lib/Renard/Incunabula/Format/PDF/InformationDictionary.pm
+++ b/lib/Renard/Incunabula/Format/PDF/InformationDictionary.pm
@@ -3,7 +3,7 @@ package Renard::Incunabula::Format::PDF::InformationDictionary;
 # ABSTRACT: represents the PDF document information dictionary
 
 use Moo;
-use Renard::Incunabula::Common::Types qw(Maybe File InstanceOf Str HashRef);
+use Renard::Incunabula::Common::Types qw(Maybe File InstanceOf Str HashRef ArrayRef);
 use Renard::Incunabula::MuPDF::mutool;
 
 =attr filename
@@ -33,6 +33,29 @@ method _get_data( (Str) $key ) {
 
 	return $obj->data if $obj;
 }
+
+=attr default_properties
+
+An C<ArrayRef> of the default properties that are expected in the information
+dictionary.
+
+=cut
+has default_properties => (
+	is => 'ro',
+	isa => ArrayRef,
+	default => sub {
+		[qw(
+			Title
+			Subject
+			Author
+			Keywords
+			Creator
+			Producer
+			CreationDate
+			ModDate
+		)]
+	},
+);
 
 =method Title
 

--- a/maint/cpanfile-git
+++ b/maint/cpanfile-git
@@ -3,4 +3,4 @@ requires 'Renard::Incunabula',
 	branch => 'master';
 requires 'Renard::Incunabula::MuPDF::mutool',
 	git => 'https://github.com/project-renard/p5-Renard-Incunabula-MuPDF-mutool.git',
-	branch => 'master';
+	branch => 'curie-13-pdf-metadata';

--- a/maint/cpanfile-git
+++ b/maint/cpanfile-git
@@ -3,4 +3,4 @@ requires 'Renard::Incunabula',
 	branch => 'master';
 requires 'Renard::Incunabula::MuPDF::mutool',
 	git => 'https://github.com/project-renard/p5-Renard-Incunabula-MuPDF-mutool.git',
-	branch => 'curie-13-pdf-metadata';
+	branch => 'master';

--- a/t/Renard/Incunabula/Format/PDF/InformationDictionary.t
+++ b/t/Renard/Incunabula/Format/PDF/InformationDictionary.t
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+
+use Test::Most;
+use Renard::Incunabula::Devel::TestHelper;
+use Renard::Incunabula::Common::Setup;
+use Renard::Incunabula::Format::PDF::InformationDictionary;
+
+my $pdf_ref_path = try {
+	Renard::Incunabula::Devel::TestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));
+} catch {
+	plan skip_all => "$_";
+};
+
+plan tests => 1;
+
+subtest pdf_ref => sub {
+	my $pdf_info = Renard::Incunabula::Format::PDF::InformationDictionary->new(
+		filename => $pdf_ref_path
+	);
+
+	my @data = (
+		[ Title        => 'PDF Reference, version 1.7' ],
+		[ Subject      => 'Adobe Portable Document Format (PDF)' ],
+		[ Author       => 'Adobe Systems Incorporated' ],
+		[ Keywords     =>  undef ],
+		[ Creator      => 'FrameMaker 7.2' ],
+		[ Producer     => 'Acrobat Distiller 7.0.5 (Windows)' ],
+		[ CreationDate => '2006-10-17T08:10:20Z' ],
+		[ ModDate      => '2006-11-18T21:10:43-02:30' ],
+	);
+
+	plan tests => 0+@data;
+
+	for my $info_pair (@data) {
+		my ($key, $value) = @$info_pair;
+		is $pdf_info->$key(), $value, "$key: @{[ $value // 'undef' ]}";
+	}
+};
+
+done_testing;


### PR DESCRIPTION
This adds a wrapper for the common fields for the PDF document
information dictionary.

Connects with <https://github.com/project-renard/curie/issues/13>.
